### PR TITLE
Add option for user-specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,37 @@ a refined and standardized user experience might be beneficial for QGIS. This
 will also facilitate initiatives like simplification.
 
 
+## Create different configs for different users and/or user groups
+
+This feature was contributed by Gesine Fengler (https://github.com/Gesine93) and enables automatic loading of
+different configuration files based on the authenticated QGIS user.
+
+This allows organizations to provide user- or role-specific simplified
+interfaces, where the visible tools and functions correspond to the
+responsibilities and permissions of the current user.
+
+The feature uses the QGIS Authentication Manager to identify the active user and
+automatically load the matching configuration file. It can be used in two ways:
+
+- **User-based configuration**: Individual users are defined in the
+  `users.json` file, and each user is assigned a dedicated configuration file.
+- **Role-based configuration**: PostgreSQL/PostGIS roles
+  are used as authenticated users, and matching
+  configuration files are loaded automatically.
+
+### Prerequisites
+
+To use this feature, the following requirements must be met:
+
+1. Users are defined either in the `users.json` file 
+   or as PostgreSQL roles and the `roles.json` contains the role.
+2. Matching authentication configurations are created in the QGIS
+   Authentication Manager.
+4. To implement the role-based-configuration, the PostgreSQL connection has to be defined in `connections.json`
+3. A QGIS Light configuration file exists for each user or role.
+
+
+
 ## Acknowledgements
 
 [Serkan Girgin](https://github.com/girgink) initiated the idea and developed

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ automatically load the matching configuration file. It can be used in two ways:
 - **Role-based configuration**: PostgreSQL/PostGIS roles
   are used as authenticated users, and matching
   configuration files are loaded automatically.
+  - **Project-based configuration**: The configuration can also be defined by project name. 
+  The project and config paths can be defined in the `projects.json`
 
 ### Prerequisites
 
@@ -270,8 +272,8 @@ To use this feature, the following requirements must be met:
    or as PostgreSQL roles and the `roles.json` contains the role.
 2. Matching authentication configurations are created in the QGIS
    Authentication Manager.
-4. To implement the role-based-configuration, the PostgreSQL connection has to be defined in `connections.json`
-3. A QGIS Light configuration file exists for each user or role.
+3. To implement the role-based-configuration, the PostgreSQL connection has to be defined in `connections.json`
+4. A QGIS Light configuration file exists for each user or role.
 
 
 

--- a/src/qgis-light/connections.json
+++ b/src/qgis-light/connections.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Verbindungsparameter für die PostgreSQL-Rollenprüfung.",
+  "host": "",
+  "port": "",
+  "dbname": ""
+}

--- a/src/qgis-light/connections.json
+++ b/src/qgis-light/connections.json
@@ -1,5 +1,4 @@
 {
-  "_comment": "Verbindungsparameter für die PostgreSQL-Rollenprüfung.",
   "host": "",
   "port": "",
   "dbname": ""

--- a/src/qgis-light/projects.json
+++ b/src/qgis-light/projects.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Projektmapping",
+  "projects": [
+    {
+      "project_names": [
+        ""
+      ],
+      "config_path": ""
+    }
+  ]
+}

--- a/src/qgis-light/qgis_light.py
+++ b/src/qgis-light/qgis_light.py
@@ -7,7 +7,8 @@ from qgis.core import (
     Qgis,
     QgsApplication,
     QgsAuthMethodConfig,
-    QgsSettings
+    QgsSettings,
+    QgsProject
 )
 from qgis.gui import (
     QgisInterface,
@@ -89,20 +90,36 @@ class QGISLightPlugin:
         users_path = os.path.join(self.plugin_dir, "users.json")
         users_cfg = self._load_json(users_path, label="User Mapping")
 
+        # load projects.json
+        projects_path = os.path.join(self.plugin_dir, "projects.json")
+        projects_cfg = self._load_json(projects_path, label="Project Mapping")
+
         # set config path
         config_path = standard_config_path  
 
 
-        # check for username in users.json
+        # 1. user mapping
         resolved = self._resolve_config_by_user(users_cfg)
+
         if resolved:
             config_path = resolved
+
         else:
-            # check for user's db role in roles.json
+            # 2. role mapping
             if connection_cfg and roles_cfg:
                 resolved = self._resolve_config_by_role(
-                    connection_cfg, roles_cfg, fallback_path=None
+                    connection_cfg,
+                    roles_cfg,
+                    fallback_path=None
                 )
+
+                if resolved:
+                    config_path = resolved
+
+            # 3. project mapping
+            if config_path == standard_config_path and projects_cfg:
+                resolved = self._resolve_config_by_project(projects_cfg)
+
                 if resolved:
                     config_path = resolved
 
@@ -288,6 +305,54 @@ class QGISLightPlugin:
 
         self.log(f"No entry for user '{self.user}' in users.json.", "info")
         return None
+    
+
+
+    def _resolve_config_by_project(self, projects_cfg: dict) -> str | None:
+        """Returns config path based on current QGIS project."""
+
+        if not projects_cfg:
+            return None
+
+        try:
+            project = QgsProject.instance()
+
+            project_path = project.fileName()
+
+            if not project_path:
+                self.log("No QGIS project loaded.", "info")
+                return None
+
+            project_name = os.path.basename(project_path)
+
+            self.log(f"Current project: {project_name}")
+
+            project_entries = projects_cfg.get("projects", [])
+
+            for entry in project_entries:
+
+                names = entry.get("project_names", [])
+
+                if project_name in names:
+
+                    cfg_path = entry.get("config_path")
+
+                    if cfg_path and os.path.isfile(cfg_path):
+                        self.log(f"Project-based config found: {cfg_path}")
+                        return cfg_path
+
+                    else:
+                        self.log(
+                            f"Invalid config for project '{project_name}': {cfg_path}",
+                            "warning"
+                        )
+
+            self.log(f"No project mapping found for '{project_name}'.", "info")
+            return None
+
+        except Exception as e:
+            self.log(f"Project mapping failed: {e}", "error")
+            return None
 
 
 

--- a/src/qgis-light/qgis_light.py
+++ b/src/qgis-light/qgis_light.py
@@ -75,65 +75,111 @@ class QGISLightPlugin:
         self.user = None
         self.matched_roles = []
 
-        # Default Config
-        standard_config_path = os.path.join(self.plugin_dir, "config.json")
+        # Default config
+        self.standard_config_path = os.path.join(
+            self.plugin_dir,
+            "config.json"
+        )
 
-        # load connection parameters from confog.json
-        connections_path = os.path.join(self.plugin_dir, "connections.json")
-        connection_cfg = self._load_json(connections_path, label="Verbindungsparameter")
+        # JSON paths
+        connections_path = os.path.join(
+            self.plugin_dir,
+            "connections.json"
+        )
 
-        # load roles.json 
-        roles_path = os.path.join(self.plugin_dir, "roles.json")
-        roles_cfg = self._load_json(roles_path, label="DB Role Mappping")
+        roles_path = os.path.join(
+            self.plugin_dir,
+            "roles.json"
+        )
 
-        # load users.json
-        users_path = os.path.join(self.plugin_dir, "users.json")
-        users_cfg = self._load_json(users_path, label="User Mapping")
+        users_path = os.path.join(
+            self.plugin_dir,
+            "users.json"
+        )
 
-        # load projects.json
-        projects_path = os.path.join(self.plugin_dir, "projects.json")
-        projects_cfg = self._load_json(projects_path, label="Project Mapping")
+        projects_path = os.path.join(
+            self.plugin_dir,
+            "projects.json"
+        )
 
-        # set config path
-        config_path = standard_config_path  
+        # Load mapping JSONs
+        self.connection_cfg = self._load_json(
+            connections_path,
+            label="Verbindungsparameter"
+        )
 
+        self.roles_cfg = self._load_json(
+            roles_path,
+            label="DB Role Mapping"
+        )
 
-        # 1. user mapping
-        resolved = self._resolve_config_by_user(users_cfg)
+        self.users_cfg = self._load_json(
+            users_path,
+            label="User Mapping"
+        )
+
+        self.projects_cfg = self._load_json(
+            projects_path,
+            label="Project Mapping"
+        )
+
+        # Resolve config
+        config_path = self.resolve_config()
+
+        if config_path == self.standard_config_path:
+            self.log(
+                "No specific mapping found – using default configuration.",
+                "info"
+            )
+
+        # active config path
+        self.config_path = config_path
+
+        # active config
+        self.config = {}
+
+        # load config
+        self.apply_config(config_path)
+
+    def resolve_config(self) -> str:
+        """Resolve active config path."""
+
+        standard_config_path = os.path.join(
+            self.plugin_dir,
+            "config.json"
+        )
+
+        config_path = standard_config_path
+
+        # 1 user
+        resolved = self._resolve_config_by_user(self.users_cfg)
 
         if resolved:
-            config_path = resolved
+            return resolved
 
-        else:
-            # 2. role mapping
-            if connection_cfg and roles_cfg:
-                resolved = self._resolve_config_by_role(
-                    connection_cfg,
-                    roles_cfg,
-                    fallback_path=None
-                )
+        # 2 role
+        if self.connection_cfg and self.roles_cfg:
 
-                if resolved:
-                    config_path = resolved
+            resolved = self._resolve_config_by_role(
+                self.connection_cfg,
+                self.roles_cfg,
+                fallback_path=None
+            )
 
-            # 3. project mapping
-            if config_path == standard_config_path and projects_cfg:
-                resolved = self._resolve_config_by_project(projects_cfg)
+            if resolved:
+                return resolved
 
-                if resolved:
-                    config_path = resolved
+        # 3 project
+        if self.projects_cfg:
 
+            resolved = self._resolve_config_by_project(
+                self.projects_cfg
+            )
 
-        if config_path == standard_config_path:
-            self.log("No specific mapping found – using default configuration.", "info")
+            if resolved:
+                return resolved
 
-        self.config = {}
-        try:
-            with open(config_path, encoding="utf-8") as f:
-                self.config = json.load(f)
-            self.log(f"Configuration loaded from {config_path}")
-        except Exception as e:
-            self.log(f"Couldn't load config file ({config_path}): {e}", "error")
+        return config_path
 
 
     def _load_json(self, path: str, label: str = "JSON") -> dict | None:
@@ -353,6 +399,53 @@ class QGISLightPlugin:
         except Exception as e:
             self.log(f"Project mapping failed: {e}", "error")
             return None
+        
+
+    def apply_config(self, config_path: str):
+        """Loads config file."""
+
+        self.config = {}
+
+        try:
+
+            with open(config_path, encoding="utf-8") as f:
+                self.config = json.load(f)
+
+            self.config_path = config_path
+
+            self.log(f"Configuration loaded from {config_path}")
+
+        except Exception as e:
+            self.log(
+                f"Couldn't load config file ({config_path}): {e}",
+                "error"
+            )
+        
+    def check_project_config(self, *args):
+        """Re-resolve config after project change."""
+
+        new_config = self.resolve_config()
+
+        # already active
+        if new_config == self.config_path:
+
+            self.log("Correct config already active.")
+            return
+
+        self.log(f"Switching config to: {new_config}")
+
+        enabled = self.settings.value("qgislight/enabled") == "true"
+
+        # disable current UI
+        if enabled:
+            self.disable(store=False)
+
+        # load new config
+        self.apply_config(new_config)
+
+        # enable again
+        if enabled:
+            self.enable(store=False)
 
 
 
@@ -764,6 +857,21 @@ class QGISLightPlugin:
 
     def initGui(self):
         """Initializes plugin user interface."""
+        # remove stale action from plugin reloads
+        existing = self.mainwindow.findChild(
+            QAction,
+            "mActionToggleQGISLight"
+        )
+
+        if existing:
+
+            self.log("Removing stale QGIS Light action.")
+
+            for widget in existing.associatedWidgets():
+                widget.removeAction(existing)
+
+            existing.deleteLater()
+        
         self.log("Initializing user interface.")
 
         # Get enabled flag
@@ -791,6 +899,9 @@ class QGISLightPlugin:
         # Add action to the view menu
         self.iface.viewMenu().addAction(action)
 
+        # signal for loading right config for project
+        QgsProject.instance().readProject.connect(self.check_project_config)
+
 
     def unload(self):
         """Unloads plugin."""
@@ -804,3 +915,10 @@ class QGISLightPlugin:
             for widget in action.associatedWidgets():
                 widget.removeAction(action)
             action.deleteLater()
+        
+        try:
+            QgsProject.instance().readProject.disconnect(
+                self.check_project_config
+            )
+        except:
+            pass

--- a/src/qgis-light/qgis_light.py
+++ b/src/qgis-light/qgis_light.py
@@ -1,9 +1,12 @@
 import os.path
 import json
+import psycopg2
+import psycopg2.extras
 
 from qgis.core import (
     Qgis,
     QgsApplication,
+    QgsAuthMethodConfig,
     QgsSettings
 )
 from qgis.gui import (
@@ -22,7 +25,9 @@ from qgis.PyQt.QtWidgets import (
     QWidgetAction
 )
 
+
 from processing import execAlgorithmDialog
+from urllib.parse import quote 
 
 
 class QGISLightPlugin:
@@ -33,6 +38,7 @@ class QGISLightPlugin:
         "info": Qgis.MessageLevel.Info,
         "warning": Qgis.MessageLevel.Warning,
         "error": Qgis.MessageLevel.Critical,
+        "success": Qgis.Success
     }
 
     # Toolbar areas
@@ -53,28 +59,236 @@ class QGISLightPlugin:
 
 
     def __init__(self, iface: QgisInterface):
-        """Initializes the plugin.
+        """Initializes the plugin."""
 
-        Args:
-            iface (QgisInterface): QGIS interface object.
-        """
-        # Set interface
+        # Interface
         self.iface = iface
-
-        # Get main window
         self.mainwindow = iface.mainWindow()
-
-        # Get settings
         self.settings = QgsSettings()
 
-        # Get plugin directory
+        # Plugin directory
         self.plugin_dir = os.path.dirname(os.path.realpath(__file__))
-        self.log(f"Plugin directory is {self.plugin_dir}.")
+        self.log(f"Plugin directory is {self.plugin_dir}")
 
-        # Load configuration
-        with open(os.path.join(self.plugin_dir, "config.json")) as file:
-            self.config = json.load(file)
-        self.log("Configuration loaded.")
+        # Defaults
+        self.user = None
+        self.matched_roles = []
+
+        # Default Config
+        standard_config_path = os.path.join(self.plugin_dir, "config.json")
+
+        # load connection parameters from confog.json
+        connections_path = os.path.join(self.plugin_dir, "connections.json")
+        connection_cfg = self._load_json(connections_path, label="Verbindungsparameter")
+
+        # load roles.json 
+        roles_path = os.path.join(self.plugin_dir, "roles.json")
+        roles_cfg = self._load_json(roles_path, label="DB Role Mappping")
+
+        # load users.json
+        users_path = os.path.join(self.plugin_dir, "users.json")
+        users_cfg = self._load_json(users_path, label="User Mapping")
+
+        # set config path
+        config_path = standard_config_path  
+
+
+        # check for username in users.json
+        resolved = self._resolve_config_by_user(users_cfg)
+        if resolved:
+            config_path = resolved
+        else:
+            # check for user's db role in roles.json
+            if connection_cfg and roles_cfg:
+                resolved = self._resolve_config_by_role(
+                    connection_cfg, roles_cfg, fallback_path=None
+                )
+                if resolved:
+                    config_path = resolved
+
+
+        if config_path == standard_config_path:
+            self.log("No specific mapping found – using default configuration.", "info")
+
+        self.config = {}
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                self.config = json.load(f)
+            self.log(f"Configuration loaded from {config_path}")
+        except Exception as e:
+            self.log(f"Couldn't load config file ({config_path}): {e}", "error")
+
+
+    def _load_json(self, path: str, label: str = "JSON") -> dict | None:
+        """Loads a JSON file and returns its content.
+
+        Returns None if the file does not exist or is invalid.
+
+        Args:
+            path: File path.
+            label: Label used for log messages.
+        """
+
+        if not os.path.isfile(path):
+            self.log(f"Couldn't find {label}: {path}", "warning")
+            return None
+        try:
+            with open(path, encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as e:
+            self.log(f"Couldn't load {label} ({path}): {e}", "error")
+            return None
+
+    def _get_auth_username(self) -> str | None:
+        """Reads the username from the QGIS Auth Manager.
+
+        Returns:
+            Username or None if no auth entry exists.
+        """
+
+        try:
+            manager = QgsApplication.authManager()
+            auth_method_cfg = QgsAuthMethodConfig()
+            auth_ids = manager.availableAuthMethodConfigs()
+            if not auth_ids:
+                return None
+            auth_id = list(auth_ids.keys())[0]
+            manager.loadAuthenticationConfig(auth_id, auth_method_cfg, True)
+            return auth_method_cfg.configMap().get("username")
+        except Exception as e:
+            self.log(f"Username could not be read from the Auth Manager: {e}", "warning")
+            return None
+
+    def _resolve_config_by_role(
+        self,
+        connection_cfg: dict,
+        roles_cfg: dict,
+        fallback_path: str | None
+    ) -> str | None:
+        """
+        Checks the database roles of the current user and returns the corresponding config path.
+
+        Args:
+            connection_cfg: Connection parameters from connections.json.
+            roles_cfg: Role mapping from roles.json.
+            fallback_path: Return value if no role matches (None = no fallback).
+
+        Returns:
+            Config path or fallback_path.
+        """
+
+        try:
+            # Retrieve auth credentials from the QGIS Auth Manager
+            manager = QgsApplication.authManager()
+            auth_ids = manager.availableAuthMethodConfigs()
+            if not auth_ids:
+                self.log("No authentication stored in QGIS – role check skipped.", "warning")
+                return fallback_path
+
+            auth_id = list(auth_ids.keys())[0]
+            auth_method_cfg = QgsAuthMethodConfig()
+            manager.loadAuthenticationConfig(auth_id, auth_method_cfg, True)
+            user = auth_method_cfg.configMap().get("username")
+            password = auth_method_cfg.configMap().get("password")
+            self.user = user
+
+            # connection parameters
+            host = connection_cfg.get("host")
+            port = int(connection_cfg.get("port", 5432))
+            dbname = connection_cfg.get("dbname")
+
+            if not host or not port or not dbname:
+                self.log("Verbindungsparameter unvollständig – Rollenprüfung übersprungen.", "warning")
+                return fallback_path
+
+            # roles
+            role_entries: list[dict] = roles_cfg.get("roles", [])
+            role_names = [entry["rolname"] for entry in role_entries if "rolname" in entry]
+
+            if not role_names:
+                self.log("Keine Rollen in roles.json definiert – Rollenprüfung übersprungen.", "warning")
+                return fallback_path
+
+            # prepare SQL
+            sql = """
+                SELECT r1.rolname
+                FROM pg_roles r
+                JOIN pg_auth_members m ON m.member = r.oid
+                JOIN pg_roles r1 ON m.roleid = r1.oid
+                WHERE r.rolname = %s
+                AND r1.rolname = ANY(%s)
+            """
+
+            # DB-connection with psycopg2 
+            conn = psycopg2.connect(
+                host=host,
+                port=port,
+                dbname=dbname,
+                user=user,
+                password=password
+            )
+            cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+            cur.execute(sql, (user, role_names))
+            rows = cur.fetchall()
+            conn.close()
+
+            self.matched_roles = [row["rolname"] for row in rows]
+
+            if not self.matched_roles:
+                self.log(f"User '{user}' does not have any of the configured roles.", "info")
+                return fallback_path
+
+            self.log(f"User '{user}' – found roles: {self.matched_roles}")
+
+            # First matching role → determine config path (priority = order in roles.json)
+
+            for entry in role_entries:
+                if entry.get("rolname") in self.matched_roles:
+                    cfg_path = entry.get("config_path")
+                    if cfg_path and os.path.isfile(cfg_path):
+                        self.log(f"Role-based config found: {cfg_path}")
+                        return cfg_path
+                    else:
+                        self.log(f"Config path for role '{entry['rolname']}' not found: {cfg_path}", "warning")
+
+            self.log("No valid role-based config – continuing with next step.", "warning")
+            return fallback_path
+
+        except Exception as e:
+            import traceback
+            self.log(f"Role check failed: {e}", "error")
+            self.log(traceback.format_exc(), "error")
+            return fallback_path
+    
+    def _resolve_config_by_user(self, users_cfg: dict) -> str | None:
+        """Returns config path based on users.json."""
+
+        if not users_cfg:
+            return None
+
+        if not self.user:
+            self.user = self._get_auth_username()
+
+        if not self.user:
+            self.log("No username available for users.json.", "warning")
+            return None
+ 
+        user_entries = users_cfg.get("users", [])
+
+        for entry in user_entries:
+            usernames = entry.get("usernames", [])
+            
+            if self.user in usernames:
+                cfg_path = entry.get("config_path")
+                if cfg_path and os.path.isfile(cfg_path):
+                    self.log(f"User-based config found: {cfg_path}")
+                    return cfg_path
+                else:
+                    self.log(f"Config for user '{self.user}' is invalid: {cfg_path}", "warning")
+
+        self.log(f"No entry for user '{self.user}' in users.json.", "info")
+        return None
+
 
 
     def log(self, message: str, level: str = "info"):
@@ -101,64 +315,6 @@ class QGISLightPlugin:
         )
 
 
-    def getProviders(self, name: bool=False) -> list[str]:
-        """Returns list of processing providers.
-
-        Args:
-            name (bool): Set True to get provider names.
-
-        Returns:
-            List of processing providers.
-        """
-        return [
-            provider.name() if name else provider.id()
-            for provider in QgsApplication.processingRegistry().providers()
-        ]
-
-
-    def getAlgorithms(self) -> list:
-        """Returns list of processing algorithms.
-
-        Returns:
-            List of processing algorithms (id, group, name).
-        """
-        algorithms = []
-
-        for provider in QgsApplication.processingRegistry().providers():
-          for algorithm in provider.algorithms():
-            algorithms.append({
-                'id': algorithm.id(),
-                'group': algorithm.group(),
-                'name': algorithm.displayName()
-            })
-
-        return algorithms
-
-
-    def getDataItemProviders(self) -> list:
-        """Returns list of data item providers.
-
-        Returns:
-            List of data item providers.
-        """
-        return [
-            provider.name()
-            for provider in QgsApplication.dataItemProviderRegistry().providers()
-        ]
-
-
-    def getDataSourceProviders(self) -> list:
-        """Returns list of data source providers.
-
-        Returns:
-            List of data source providers.
-        """
-        return [
-            provider.name()
-            for provider in QgsGui.sourceSelectProviderRegistry().providers()
-        ]
-
-
     def findAction(self, widget: QWidget, id: str) -> QAction:
         """Finds action with the specified identifier.
 
@@ -177,16 +333,9 @@ class QGISLightPlugin:
                 action = self.findAction(action.defaultWidget(), id)
 
             elif id in [action.objectName(), action.text(), action.toolTip()]:
-                pass
-
-            elif action.menu():
-                action = self.findAction(action.menu(), id)
-
-            else:
-                continue
-
-            if action:
                 return action
+
+        return None
 
 
     def getItems(self, token: str) -> list:
@@ -316,13 +465,36 @@ class QGISLightPlugin:
                 self.log(f"Invalid item {item}.", "warning")
 
 
-    def restoreLayout(self):
-        """Restores layout of the user interface.
 
-        Toolbars and panels are restored to the layout that was stored before
-        the simplifications were enabled.
-        """
-        self.log("Restoring user interface layout.")
+
+
+    def saveLayout(self):
+
+        # Save toolbars
+        items = []
+        for toolbar in self.mainwindow.findChildren(QToolBar):
+            if toolbar.parent() == self.mainwindow:
+                items.append({
+                    "name": toolbar.objectName(),
+                    "area": self.mainwindow.toolBarArea(toolbar),
+                })
+        self.settings.setValue("qgislight/toolbars", items)
+        self.log("Toolbars saved.")
+
+        # Save panels
+        items = []
+        for panel in self.mainwindow.findChildren(QDockWidget):
+            items.append({
+                "name": panel.objectName(),
+                "area": self.mainwindow.dockWidgetArea(panel),
+                "features": panel.features(),
+                "hidden": panel.isHidden(),
+            })
+        self.settings.setValue("qgislight/panels", items)
+        self.log("Panels saved.")
+
+
+    def restoreLayout(self):
 
         # Restore toolbars
         items = self.settings.value("qgislight/toolbars", [])
@@ -456,6 +628,12 @@ class QGISLightPlugin:
             )
             self.addItems(toolbar, item["items"])
             toolbar.show()
+
+        # Such-Plugin Discovery einblenden - TS
+        suche = self.mainwindow.findChild(QToolBar, "Discovery_Plugin")
+        if suche:
+            suche.show()
+            self.mainwindow.insertToolBar(suche, toolbar) # Discovery nach rechts
 
         # Set up panels
         panels = self.config.get("panels", {})

--- a/src/qgis-light/roles.json
+++ b/src/qgis-light/roles.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Rollenmapping: Welche pgAdmin-Rolle bekommt welche Config? Reihenfolge bestimmt Priorität (erste Übereinstimmung gewinnt).",
+  "roles": [
+    {
+      "rolname": "",
+      "config_path": ""
+    }
+  ]
+}

--- a/src/qgis-light/users.json
+++ b/src/qgis-light/users.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Nutzerspezifisches Config-Mapping. Greift nur wenn keine Rolle aus roles.json passt. Reihenfolge ist irrelevant – Abgleich erfolgt auf exakten Benutzernamen.",
+  "users": [
+    {
+      "usernames": [],
+      "config_path": ""
+    }
+  ]
+}


### PR DESCRIPTION
I added support for loading different QGIS Light configuration files based on the authenticated QGIS user.

The feature uses the QGIS Authentication Manager to determine the active user and automatically applies a matching configuration. This makes it possible to provide user- or role-specific interfaces.

The configuration can either be mapped by username or by database role (PostgreSQL).