### PR TITLE
Port to QGIS 4 / Qt6 while keeping QGIS 3.22+ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ non-technical QGIS users, can be found in the following resources:
   https://doi.org/10.5281/zenodo.16082546
 
 
+## Compatibility
+
+QGIS Light runs on QGIS 3.22 or later, including QGIS 4. A single codebase
+supports both the Qt 5 (QGIS 3) and Qt 6 (QGIS 4) builds.
+
+
 ## How to simplify the QGIS interface?
 
 > [!NOTE]

--- a/src/qgis-light/metadata.txt
+++ b/src/qgis-light/metadata.txt
@@ -4,8 +4,8 @@ description=QGIS made simple - a light user interface for core GIS functions.
 about=This plugin simplifies the QGIS user interface by reducing the number of
     toolbars, panels, and widgets.
 version=0.1.1
-qgisMinimumVersion=3.22
-qgisMaximumVersion=3.99
+qgisMinimumVersion=4.0
+qgisMaximumVersion=4.99
 author=Serkan Girgin
 email=girgink@gmail.com
 icon=icons/qgis-green.png

--- a/src/qgis-light/metadata.txt
+++ b/src/qgis-light/metadata.txt
@@ -4,7 +4,7 @@ description=QGIS made simple - a light user interface for core GIS functions.
 about=This plugin simplifies the QGIS user interface by reducing the number of
     toolbars, panels, and widgets.
 version=0.1.1
-qgisMinimumVersion=4.0
+qgisMinimumVersion=3.22
 qgisMaximumVersion=4.99
 author=Serkan Girgin
 email=girgink@gmail.com

--- a/src/qgis-light/qgis_light.py
+++ b/src/qgis-light/qgis_light.py
@@ -37,18 +37,18 @@ class QGISLightPlugin:
 
     # Toolbar areas
     _toolbar_areas = {
-        "top": Qt.TopToolBarArea,
-        "bottom": Qt.BottomToolBarArea,
-        "left": Qt.LeftToolBarArea,
-        "right": Qt.RightToolBarArea,
+        "top": Qt.ToolBarArea.TopToolBarArea,
+        "bottom": Qt.ToolBarArea.BottomToolBarArea,
+        "left": Qt.ToolBarArea.LeftToolBarArea,
+        "right": Qt.ToolBarArea.RightToolBarArea,
     }
 
     # Panel areas
     _panel_areas = {
-        "top": Qt.TopDockWidgetArea,
-        "bottom": Qt.BottomDockWidgetArea,
-        "left": Qt.LeftDockWidgetArea,
-        "right": Qt.RightDockWidgetArea,
+        "top": Qt.DockWidgetArea.TopDockWidgetArea,
+        "bottom": Qt.DockWidgetArea.BottomDockWidgetArea,
+        "left": Qt.DockWidgetArea.LeftDockWidgetArea,
+        "right": Qt.DockWidgetArea.RightDockWidgetArea,
     }
 
 
@@ -235,7 +235,7 @@ class QGISLightPlugin:
             toolbutton = QToolButton(self.mainwindow)
             toolbutton.setIcon(QIcon(algorithms["icon"]))
             toolbutton.setMenu(menu)
-            toolbutton.setPopupMode(QToolButton.MenuButtonPopup)
+            toolbutton.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
 
             return [toolbutton]
 
@@ -256,11 +256,11 @@ class QGISLightPlugin:
             if not wildcard:
                 return [action]
 
-            for widget in action.associatedWidgets():
+            for widget in action.associatedObjects():
                 if isinstance(widget, QToolButton):
                     return [widget.menu()] if widget.menu() else widget.actions()
 
-            for widget in action.associatedWidgets():
+            for widget in action.associatedObjects():
                 if isinstance(widget, QMenu):
                     return [widget]
 
@@ -304,7 +304,7 @@ class QGISLightPlugin:
                 else:
                     toolbutton = QToolButton(self.mainwindow)
                     toolbutton.setMenu(item)
-                    toolbutton.setPopupMode(QToolButton.MenuButtonPopup)
+                    toolbutton.setPopupMode(QToolButton.ToolButtonPopupMode.MenuButtonPopup)
                     toolbutton.setDefaultAction(item.actions()[0])
                     item.triggered.connect(toolbutton.setDefaultAction)
                     parent.addWidget(toolbutton)
@@ -351,7 +351,7 @@ class QGISLightPlugin:
             if self.mainwindow.dockWidgetArea(panel) != item["area"]:
                 self.mainwindow.addDockWidget(item["area"], panel)
 
-            panel.setFeatures(QDockWidget.DockWidgetFeatures(item["features"]))
+            panel.setFeatures(item["features"])
 
             if item["hidden"]:
                 panel.hide()
@@ -376,7 +376,7 @@ class QGISLightPlugin:
         self.mainwindow.menuBar().show()
 
         # Enable contextual menu
-        self.mainwindow.setContextMenuPolicy(Qt.DefaultContextMenu)
+        self.mainwindow.setContextMenuPolicy(Qt.ContextMenuPolicy.DefaultContextMenu)
 
         # Remove simplified toolbars
         for name in self.config["toolbars"]:
@@ -425,7 +425,7 @@ class QGISLightPlugin:
         self.mainwindow.menuBar().hide()
 
         # Disable contextual menu
-        self.mainwindow.setContextMenuPolicy(Qt.NoContextMenu)
+        self.mainwindow.setContextMenuPolicy(Qt.ContextMenuPolicy.NoContextMenu)
 
         # Set up toolbars
         items = []
@@ -451,7 +451,7 @@ class QGISLightPlugin:
             toolbar.setMovable(False)
             toolbar.toggleViewAction().setDisabled(True)
             self.mainwindow.addToolBar(
-                self._toolbar_areas.get(item["area"], Qt.TopToolBarArea),
+                self._toolbar_areas.get(item["area"], Qt.ToolBarArea.TopToolBarArea),
                 toolbar
             )
             self.addItems(toolbar, item["items"])
@@ -480,11 +480,11 @@ class QGISLightPlugin:
                 continue
             state, area = panels[name].split(":", 1)
             self.mainwindow.addDockWidget(
-                self._panel_areas.get(area, Qt.LeftDockWidgetArea),
+                self._panel_areas.get(area, Qt.DockWidgetArea.LeftDockWidgetArea),
                 panel
             )
             if state == "fixed":
-                panel.setFeatures(QDockWidget.NoDockWidgetFeatures)
+                panel.setFeatures(QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
                 panel.show()
             elif state == "hidden":
                 panel.hide()
@@ -558,6 +558,6 @@ class QGISLightPlugin:
         # Remove enable simplifications action if required
         action = self.mainwindow.findChild(QAction, "mActionToggleQGISLight")
         if action:
-            for widget in action.associatedWidgets():
+            for widget in action.associatedObjects():
                 widget.removeAction(action)
             action.deleteLater()

--- a/src/qgis-light/qgis_light.py
+++ b/src/qgis-light/qgis_light.py
@@ -101,6 +101,44 @@ class QGISLightPlugin:
         )
 
 
+    @staticmethod
+    def associatedObjects(action: QAction) -> list:
+        """Returns objects associated with an action.
+
+        Bridges a Qt version difference: QAction.associatedWidgets() was
+        renamed to associatedObjects() when QAction moved to QtGui in Qt6.
+
+        Args:
+            action (QAction): Action object.
+
+        Returns:
+            List of associated objects.
+        """
+        if hasattr(action, "associatedObjects"):
+            return action.associatedObjects()
+        return action.associatedWidgets()
+
+
+    @staticmethod
+    def toEnum(enum_type, value):
+        """Coerces a value read from settings to a Qt enum type.
+
+        QgsSettings preserves Qt enum types under Qt6 but returns plain
+        integers under Qt5, so stored toolbar/panel areas and feature flags
+        must be normalized before they are passed back to Qt.
+
+        Args:
+            enum_type: Target Qt enum or flag type.
+            value: Value read from settings (an enum/flag or an integer).
+
+        Returns:
+            The value as an instance of enum_type.
+        """
+        if isinstance(value, enum_type):
+            return value
+        return enum_type(value)
+
+
     def getProviders(self, name: bool=False) -> list[str]:
         """Returns list of processing providers.
 
@@ -256,11 +294,11 @@ class QGISLightPlugin:
             if not wildcard:
                 return [action]
 
-            for widget in action.associatedObjects():
+            for widget in self.associatedObjects(action):
                 if isinstance(widget, QToolButton):
                     return [widget.menu()] if widget.menu() else widget.actions()
 
-            for widget in action.associatedObjects():
+            for widget in self.associatedObjects(action):
                 if isinstance(widget, QMenu):
                     return [widget]
 
@@ -333,8 +371,9 @@ class QGISLightPlugin:
                 self.log(f"Toolbar {item['name']} not found.", "warning")
                 continue
 
-            if self.mainwindow.toolBarArea(toolbar) != item["area"]:
-                self.mainwindow.addToolBar(item["area"], toolbar)
+            area = self.toEnum(Qt.ToolBarArea, item["area"])
+            if self.mainwindow.toolBarArea(toolbar) != area:
+                self.mainwindow.addToolBar(area, toolbar)
 
             toolbar.show()
             self.log(f"Toolbar {item['name']} is visible.")
@@ -348,10 +387,11 @@ class QGISLightPlugin:
                 self.log(f"Panel {item['name']} not found.", "warning")
                 continue
 
-            if self.mainwindow.dockWidgetArea(panel) != item["area"]:
-                self.mainwindow.addDockWidget(item["area"], panel)
+            area = self.toEnum(Qt.DockWidgetArea, item["area"])
+            if self.mainwindow.dockWidgetArea(panel) != area:
+                self.mainwindow.addDockWidget(area, panel)
 
-            panel.setFeatures(item["features"])
+            panel.setFeatures(self.toEnum(QDockWidget.DockWidgetFeature, item["features"]))
 
             if item["hidden"]:
                 panel.hide()
@@ -558,6 +598,6 @@ class QGISLightPlugin:
         # Remove enable simplifications action if required
         action = self.mainwindow.findChild(QAction, "mActionToggleQGISLight")
         if action:
-            for widget in action.associatedObjects():
+            for widget in self.associatedObjects(action):
                 widget.removeAction(action)
             action.deleteLater()


### PR DESCRIPTION
## Summary

QGIS 4 ships Qt 6 / PyQt6. QGIS Light did not support it: `metadata.txt`
declared `qgisMaximumVersion=3.99`, so QGIS 4 refused to load the plugin, and
the code relied on Qt5-only enum and API forms.

This ports the plugin to run on **QGIS 4.x** while keeping **QGIS 3.22+**
working, from a single codebase.

## Changes

- **Qt6 enum scoping** — PyQt6 requires fully-qualified enum names
  (`Qt.ToolBarArea.TopToolBarArea`, `QToolButton.ToolButtonPopupMode.MenuButtonPopup`,
  `QDockWidget.DockWidgetFeature.*`, `Qt.ContextMenuPolicy.*`). PyQt5 5.15
  accepts the same syntax, so this stays QGIS 3 compatible.
- **`QAction.associatedWidgets()` → `associatedObjects()`** — `QAction` moved to
  QtGui in Qt6 and the accessor was renamed. A small `associatedObjects()` helper
  picks whichever method the running Qt provides.
- **Settings round-trip** — `QgsSettings` preserves Qt enum types under Qt6 but
  returns plain integers under Qt5, which PyQt5 5.15 then rejects where an enum
  is expected. A `toEnum()` helper normalizes stored toolbar/panel areas and
  panel feature flags in `restoreLayout()`.
- **metadata.txt** — `qgisMinimumVersion=3.22`, `qgisMaximumVersion=4.99`.
- **README** — added a Compatibility section.

## Testing

Loaded the plugin and toggled simplified mode on and off in:

- QGIS 4.0.2 (Qt 6.11 / PyQt6)
- QGIS 3.44.10 LTR (Qt 5.15 / PyQt5)

Enable, disable, and layout restore all work on both. The helpers and the exact
Qt call sites were additionally checked against both PyQt5 5.15 and PyQt6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)